### PR TITLE
Update manifest and meta theme-colors

### DIFF
--- a/input/shared/_LayoutDefault.cshtml
+++ b/input/shared/_LayoutDefault.cshtml
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" data-sh-theme="moon">
+<html lang="en" data-sh-theme="bubblegum">
 @Html.Partial("~/shared/_LayoutHead.cshtml")
 <body class='@(Document.Keys.Contains("CenteredLayout") ? "bg-alpha" : "")'>
     @Html.Partial("~/shared/_LayoutBodyOpening.cshtml")

--- a/input/shared/_LayoutHead.cshtml
+++ b/input/shared/_LayoutHead.cshtml
@@ -7,6 +7,7 @@
     }
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="theme-color" content="#557efe">
     <meta name="description" content="@description" />
     @* Open Graph data *@
     <meta property="og:title" content="@title" />

--- a/input/shared/_LayoutPost.cshtml
+++ b/input/shared/_LayoutPost.cshtml
@@ -3,7 +3,7 @@
     string shareUrl = @Context.GetLink().TrimEnd('/') + Document.GetLink();
 }
 <!DOCTYPE html>
-<html lang="en" data-sh-theme="moon">
+<html lang="en" data-sh-theme="bubblegum">
 @Html.Partial("~/shared/_LayoutHead.cshtml")
 <body class="bg-alpha">
     @Html.Partial("~/shared/_LayoutBodyOpening.cshtml")

--- a/input/site.webmanifest
+++ b/input/site.webmanifest
@@ -1,19 +1,19 @@
 {
-    "name": "",
-    "short_name": "",
-    "icons": [
-      {
-        "src": "/android-chrome-192x192.png",
-        "sizes": "192x192",
-        "type": "image/png"
-      },
-      {
-        "src": "/android-chrome-512x512.png",
-        "sizes": "512x512",
-        "type": "image/png"
-      }
-    ],
-    "theme_color": "#557efe",
-    "background_color": "#557efe",
-    "display": "standalone"
-  }
+  "name": "Steph Hays Personal Website",
+  "start_url": "/",
+  "icons": [
+    {
+      "src": "/android-chrome-192x192.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "/android-chrome-512x512.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    }
+  ],
+  "background_color": "#557efe",
+  "theme_color": "#557efe",
+  "display": "browser"
+}


### PR DESCRIPTION
This updates the site.webmanifest file to include the needed fields. In addition the theme-color meta tag has been set in the head. The default theme has been switched to "bubblegum".